### PR TITLE
Update PHP version constraint to allow PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "~5.3",
+        "php": "~5.3|~7.0",
         "zf-commons/zfc-user": "~1.2"
     },
     "require-dev": {


### PR DESCRIPTION
Not able to install this module on PHP 7 due to the version constraint in composer.json (`~5.3`):

``` bash
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - eye4web/e4w-zfc-user-redirect-url 0.0.x-dev requires php ~5.3 -> your PHP version (7.0.0-5+deb.sury.org~wily+1) or "config.platform.php" value does not satisfy that requirement.
    - eye4web/e4w-zfc-user-redirect-url 0.0.x-dev requires php ~5.3 -> your PHP version (7.0.0-5+deb.sury.org~wily+1) or "config.platform.php" value does not satisfy that requirement.
    - Installation request for eye4web/e4w-zfc-user-redirect-url 0.0.x-dev -> satisfiable by eye4web/e4w-zfc-user-redirect-url[0.0.x-dev].

```

This PR updates the constraint to match ZfcUser (currently `>=5.3.3`)
