### PR TITLE
Reject redirect on // prefix

### DIFF
--- a/src/E4W/ZfcUser/RedirectUrl/Controller/RedirectCallback.php
+++ b/src/E4W/ZfcUser/RedirectUrl/Controller/RedirectCallback.php
@@ -111,7 +111,7 @@ class RedirectCallback
         }
         $domain = parse_url($url, PHP_URL_HOST);
 
-        if (strpos($url, "/") === 0 || in_array($domain, $whitelisted_domains)) {
+        if ((substr($url, 0, 2) !== '//' && strpos($url, '/') === 0) || in_array($domain, $whitelisted_domains)) {
             return true;
         }
 


### PR DESCRIPTION
It is possible to bypass the whitelist by using a redirect with a schema-less url:

```
?redirect=//nonwhitelisteddomain.com/path/to/page
```

which opens up a possible phishing attack via Unvalidated Redirect: 

https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet

This tweak closes the whitelist bypass while still allowing root-absolute destinations.